### PR TITLE
Shutdown executor and set thread to daemon. Resolves #1

### DIFF
--- a/src/main/java/github/totorewa/asyncchat/AsyncChatMod.java
+++ b/src/main/java/github/totorewa/asyncchat/AsyncChatMod.java
@@ -13,4 +13,10 @@ public class AsyncChatMod implements ModInitializer {
     public static ChatMessageDispatcher getChatMessageDispatcher() {
         return chatMessageDispatcher;
     }
+
+    public static void shutdown() {
+        if (chatMessageDispatcher != null) {
+            chatMessageDispatcher.dispose();
+        }
+    }
 }

--- a/src/main/java/github/totorewa/asyncchat/ChatMessageDispatcher.java
+++ b/src/main/java/github/totorewa/asyncchat/ChatMessageDispatcher.java
@@ -10,14 +10,25 @@ import java.util.concurrent.Executors;
 
 public class ChatMessageDispatcher {
     private final ExecutorService executor;
+    private boolean disposed;
 
     public ChatMessageDispatcher() {
-        executor = Executors.newSingleThreadExecutor();
+        executor = Executors.newSingleThreadExecutor((r) -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
     }
 
     public void handleMessage(InGameHud hud, MessageType type, Text message, UUID sender) {
+        if (disposed) return;
         // Not fully async because the thread will still block on the blocklist fetch request
         // but at least the thread being blocked isn't the main thread.
         executor.submit(() -> hud.addChatMessage(type, message, sender));
+    }
+
+    public void dispose() {
+        executor.shutdown();
+        disposed = true;
     }
 }

--- a/src/main/java/github/totorewa/asyncchat/mixins/MinecraftClientMixin.java
+++ b/src/main/java/github/totorewa/asyncchat/mixins/MinecraftClientMixin.java
@@ -1,0 +1,16 @@
+package github.totorewa.asyncchat.mixins;
+
+import github.totorewa.asyncchat.AsyncChatMod;
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftClient.class)
+public class MinecraftClientMixin {
+    @Inject(method = "close", at = @At("HEAD"))
+    private void disposeChatMessageDispatcher(CallbackInfo ci) {
+        AsyncChatMod.shutdown();
+    }
+}


### PR DESCRIPTION
A custom thread factory is passed in to java.util.concurrent.Executors#newSingleThreadExecutor() which sets the thread to daemon. The Minecraft client shutdown is also hooked to dispose the executor.